### PR TITLE
Read Table Fields using STATE=M

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -864,6 +864,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       EXPORTING
         name          = lv_name
         langu         = mv_language
+        state         = 'M'
       IMPORTING
         dd02v_wa      = ls_dd02v
         dd09l_wa      = ls_dd09l


### PR DESCRIPTION
State M also retrieves disabled (by Switch) fields. 
With State=A the switched structures are empty tables without fields which the Linter does not like.

[SCI Issue 1444](https://github.com/abaplint/abaplint/issues/1444)